### PR TITLE
Fixed Facebook scope.

### DIFF
--- a/6-Managing-Authentication-with-Passport/app/routes/users.server.routes.js
+++ b/6-Managing-Authentication-with-Passport/app/routes/users.server.routes.js
@@ -23,7 +23,8 @@ module.exports = function(app) {
 
 	// Set up the Facebook OAuth routes 
 	app.get('/oauth/facebook', passport.authenticate('facebook', {
-		failureRedirect: '/signin'
+		failureRedirect: '/signin',
+		scope: ['email']
 	}));
 	app.get('/oauth/facebook/callback', passport.authenticate('facebook', {
 		failureRedirect: '/signin',


### PR DESCRIPTION
scope: ['email'] needs to be included so that the email is passed back, and a local user can be made.
